### PR TITLE
Workflows update

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       matrix:
         sc: [no-self-contained, self-contained]
-    runs-on: macos-14
+    runs-on: macos-13
     env:
       APP_NAME: coolgirl-multirom-builder
       OUTPUT_DIR: coolgirl-multirom-builder

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       matrix:
         sc: [no-self-contained, self-contained]
-    runs-on: macos-latest
+    runs-on: macos-14
     env:
       APP_NAME: coolgirl-multirom-builder
       OUTPUT_DIR: coolgirl-multirom-builder

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         sc: [no-self-contained, self-contained]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       APP_NAME: coolgirl-multirom-builder
       OUTPUT_DIR: coolgirl-multirom-builder
@@ -65,7 +65,7 @@ jobs:
       run: |
         ${{ env.CMD }} ${{ env.OUTPUT_FILE_X64 }} ${{ env.OUTPUT_DIR }}
     - name: Upload artifact for Linux-x64
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.APP_NAME }}-linux-x64-${{ matrix.sc }}
         path: ${{ env.OUTPUT_FILE_X64 }}
@@ -91,7 +91,7 @@ jobs:
       run: |
         ${{ env.CMD }} ${{ env.OUTPUT_FILE_ARM32 }} ${{ env.OUTPUT_DIR }}
     - name: Upload artifact for Linux-ARM32
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.APP_NAME }}-linux-arm32-${{ matrix.sc }}
         path: ${{ env.OUTPUT_FILE_ARM32 }}
@@ -117,7 +117,7 @@ jobs:
       run: |
         ${{ env.CMD }} ${{ env.OUTPUT_FILE_ARM64 }} ${{ env.OUTPUT_DIR }}
     - name: Upload artifact for Linux-ARM64
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.APP_NAME }}-linux-arm64-${{ matrix.sc }}
         path: ${{ env.OUTPUT_FILE_ARM64 }}
@@ -169,7 +169,7 @@ jobs:
       run: |
         ${{ env.CMD }} ${{ env.OUTPUT_FILE }} ${{ env.OUTPUT_DIR }}
     - name: Upload artifact for MacOS-x64
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.APP_NAME }}-osx-x64-${{ matrix.sc }}
         path: ${{ env.OUTPUT_FILE }}
@@ -235,14 +235,14 @@ jobs:
       run: |
         ${{ env.CMD }} ${{ env.OUTPUT_FILE }} ${{ env.OUTPUT_DIR }}
     - name: Upload artifact for Win-x64
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.APP_NAME }}-win-x64-${{ matrix.sc }}
         path: ${{ env.OUTPUT_FILE }}
 
   upload-to-pages:
     needs: [build-linux, build-macos, build-windows]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v4.1.7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   create-release: 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Create Release
       id: create_release
@@ -19,7 +19,7 @@ jobs:
     - name: Output Release URL File
       run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt
     - name: Save Release URL File for publish
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release_url
         path: release_url.txt
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         sc: [no-self-contained, self-contained]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       APP_NAME: coolboy-multirom-builder
       OUTPUT_DIR: coolboy-multirom-builder

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,7 +162,7 @@ jobs:
     strategy:
       matrix:
         sc: [no-self-contained, self-contained]
-    runs-on: macos-14
+    runs-on: macos-13
     env:
       APP_NAME: coolboy-multirom-builder
       OUTPUT_DIR: coolboy-multirom-builder

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,7 +162,7 @@ jobs:
     strategy:
       matrix:
         sc: [no-self-contained, self-contained]
-    runs-on: macos-latest
+    runs-on: macos-14
     env:
       APP_NAME: coolboy-multirom-builder
       OUTPUT_DIR: coolboy-multirom-builder


### PR DESCRIPTION
Some changes to make the workflows work:
1) Bumped upload-artifact from v3 to v4 to avoid deprecation error
2) Downgraded ubuntu-latest to ubuntu-20.04 to allow running the assembler in older linux distributions (As the assembler is linked with glibc, that kind of limits how old the distro's glibc can be)
3) Downgraded macos-latest to macos-13. The assembler won't build for mac silicon because it can't find -largp. macos-13 does not run into this problem so this will fix the workflow builds until the assembler makefile is updated to work on newer macos systems.